### PR TITLE
Build pipenv in bootstrap, use ruamel.yaml

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ verify_ssl = true
 
 [packages]
 pandas = "*"
-PyYaml = "*"
+"ruamel.yaml" = "*"
 
 [requires]
 python_version = "3.9"

--- a/recurr_txns.py
+++ b/recurr_txns.py
@@ -4,8 +4,8 @@ Recurring Transactions Generator
 
 from datetime import datetime
 from operator import itemgetter
+from ruamel.yaml import YAML
 import sys
-import yaml
 
 from dateutil.rrule import (
     rrule,
@@ -71,7 +71,7 @@ def show_txn_str(txn_dict, tab_map_dict):
 def main(yaml_config_file, output_to_file):
     """Get all recurring transactions and show them formatted properly."""
     with open(yaml_config_file) as yaml_file:
-        raw_config = yaml.safe_load(yaml_file)
+        raw_config = YAML(typ="safe").load(yaml_file)
 
     recurr_txns = get_recurr_txns(raw_config)
     default_until = datetime.combine(

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,1 +1,6 @@
+#!/bin/bash
+pip install --upgrade pip
+pip install --no-cache-dir pipenv
+
+pipenv --python 3.9
 pipenv install --dev

--- a/script/setup
+++ b/script/setup
@@ -1,0 +1,2 @@
+#!/bin/bash
+mkdir -p results


### PR DESCRIPTION
### What

* Set up and build the `pipenv` in `script/bootstrap`
* Use `ruamel.yaml` instead of `PyYaml`

### Why

* For now, running locally with `pipenv` will be more straightforward than using Docker
* [`ruamel.yaml` supports YAML 1.2](https://yaml.readthedocs.io/en/latest/pyyaml.html#:~:text=PyYAML%20supports%20the%20YAML%201.1,1.2%20as%20released%20in%202009.&text=YAML%201.2%20no%20longer%20accepts,one%20or%20more%20octal%20characters)