### PR TITLE
Update Dockerfile and docs, and add Makefile commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,18 @@
-FROM python:3.7.3-stretch
+FROM python:3.9.1-slim
 
 RUN \
-    pip install \
-    numpy==1.16.3 \
-    pandas==0.24.2 \
-    PyYAML==5.1
+      pip3 install --upgrade pip \
+      && pip3 install --no-cache-dir pipenv
 
 WORKDIR /app
-COPY . /app
 
-ENTRYPOINT ["python", "recurr_txns.py"]
+COPY ./Pipfile ./Pipfile
+COPY ./Pipfile.lock ./Pipfile.lock
+
+RUN pipenv install --deploy
+
+COPY ./lib ./lib
+ADD ./input ./input
+RUN mkdir results
+
+ENTRYPOINT ["pipenv", "run", "python", "lib/recurr_txns.py"]

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,8 @@
+build:
+	docker build --pull -t recurr_txns:latest .
+
+run: build
+	docker run -it recurr_txns:latest $(INPUT_FILE)
+
 format:
 	pipenv run black .

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Generate recurring transactions in a spreadsheet-friendly format
 
 ## Getting started
 
-Run `script/bootstrap` to install the `pipenv` environment.
+* Run `script/bootstrap` to install the `pipenv` environment
+* Run `script/setup` to create required directory
 
 ## Sample transactions
 
 Add transactions to a YAML under the `recurr_txns` key. There are examples in
-`sample_txns.yaml` like this:
+`input/sample_txns.yaml` like this:
 
 ```yaml
 recurr_txns:
@@ -25,8 +26,27 @@ recurr_txns:
 
 ## Running it
 
-Use the following command to generate the transactions
+* Run locally after running setup steps above:
 
 ```zsh
-pipenv run python lib/recurr_txns.py sample_txns.yaml
+pipenv run python lib/recurr_txns.py input/sample_txns.yaml
+
+['02/12/2021', 'John Doe; Childcare', '', '', '$-100.00']
+['02/12/2021', 'My employer; Pay estimate', '', '', '$1000.00']
+['02/14/2021', 'State Farm; Insurance payment', '', '', '$-75.00']
+['02/19/2021', 'John Doe; Childcare', '', '', '$-100.00']
+['02/26/2021', 'John Doe; Childcare', '', '', '$-100.00']
+['02/26/2021', 'My employer; Pay estimate', '', '', '$1000.00']
+
+[ ... ]
 ```
+
+* Alternatively, run with Docker via `Makefile`. The transactions file **must be** placed in the `input/` directory:
+
+```bash
+make INPUT_FILE=input/your_txns.yaml run
+```
+
+## Building it
+
+`make build` will build the Docker image.

--- a/input/sample_txns.yaml
+++ b/input/sample_txns.yaml
@@ -32,6 +32,6 @@ recurr_txns:
     rrule:
       freq: YEARLY
       interval: 1
-      dtstart: 2018-10-01
+      dtstart: 2021-10-01
     account: Credit Card
     amount: -110.00


### PR DESCRIPTION
### What

* Update `Dockerfile` to use a lighter-weight Python image as well as using `pipenv` in the same way it can be used locally
* Add `build` and `run` commands to `Makefile`
* Move and tweak the sample YAML
* Update the docs to reflect the above and provide sample output

### Why

* Docker is now another way to run the main program and will use the same dependencies as running locally
* These commands will make iteration and usage of Docker easier
* Using the `input/` directory will be simpler and changed date will mean cleaner example output
* So that people can use it!

Closes #13