### PR TITLE
GH-13 Reformat examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ pipenv run python lib/recurr_txns.py input/sample_txns.yaml
 * Alternatively, run with Docker via `Makefile`. The transactions file **must be** placed in the `input/` directory:
 
 ```bash
-make INPUT_FILE=input/your_txns.yaml run
+make run INPUT_FILE=input/your_txns.yaml
 ```
 
 ## Building it
 
-`make build` will build the Docker image.
+```bash
+make build  # Builds the Docker image
+```


### PR DESCRIPTION
### What

Update the `make run` and `make build` examples in the README

### Why

It reads more cleanly to:

- Include the `INPUT_FILE` parameter at the end of `make run`
- Use a full code block with a comment to explain `make build`

Relates to #13