### PR TITLE
GH-6 - Add Github Actions workflow, update .gitignore

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,26 @@
+name: Python project
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build_lint_and_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        script/bootstrap
+    - name: Lint and check black formatting
+      run: |
+        pipenv run black --check --diff .
+    - name: Test with pytest
+      run: |
+        pipenv run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
-*.yaml
+# Do not allow any input or results files to be committed
+input/*
 results/*
+
+# For extra safety, do not allow any YAML files
+*.yaml
+*.yml


### PR DESCRIPTION
### What

* Add a Github Actions workflow for project that will run on pull requests and pushes to `main`
* Exclude `input/` and `results/` folders, along with both YAML extensions, from being committed to `git`

### Why

* This will help catch formatting errors and test failures sooner
* The result CSV and input YAML files, whether they are in `input/` or elsewhere, will likely contain sensitive transaction information that should not be committed.

Closes #6