### PR TITLE
GH-18 Downgrade python to 3.7

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.7
     - name: Install dependencies
       run: |
         script/bootstrap
-    - name: Lint and check black formatting
+    - name: Check black formatting
       run: |
         pipenv run black --check --diff .
     - name: Test with pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.1-slim
+FROM python:3.7-slim
 
 RUN \
       pip3 install --upgrade pip \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	docker build --pull -t recurr_txns:latest .
+	docker build -t recurr_txns:latest .
 
 run: build
 	docker run -it recurr_txns:latest $(INPUT_FILE)

--- a/Pipfile
+++ b/Pipfile
@@ -14,4 +14,4 @@ python-dateutil = "==2.8.1"
 "ruamel.yaml" = "==0.16.12"
 
 [requires]
-python_version = "3.9"
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1cb42a14946a20e66e9388dc1b7b6631a227d6494b1f69c12e44e24ababe80b3"
+            "sha256": "46809f9fb785e0a92d8f9681d4bf52f201f771628de3bc1965fbcfdd4009a785"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -31,6 +31,43 @@
             ],
             "index": "pypi",
             "version": "==0.16.12"
+        },
+        "ruamel.yaml.clib": {
+            "hashes": [
+                "sha256:058a1cc3df2a8aecc12f983a48bda99315cebf55a3b3a5463e37bb599b05727b",
+                "sha256:1236df55e0f73cd138c0eca074ee086136c3f16a97c2ac719032c050f7e0622f",
+                "sha256:1f8c0a4577c0e6c99d208de5c4d3fd8aceed9574bb154d7a2b21c16bb924154c",
+                "sha256:2602e91bd5c1b874d6f93d3086f9830f3e907c543c7672cf293a97c3fabdcd91",
+                "sha256:28116f204103cb3a108dfd37668f20abe6e3cafd0d3fd40dba126c732457b3cc",
+                "sha256:2d24bd98af676f4990c4d715bcdc2a60b19c56a3fb3a763164d2d8ca0e806ba7",
+                "sha256:2fd336a5c6415c82e2deb40d08c222087febe0aebe520f4d21910629018ab0f3",
+                "sha256:30dca9bbcbb1cc858717438218d11eafb78666759e5094dd767468c0d577a7e7",
+                "sha256:44c7b0498c39f27795224438f1a6be6c5352f82cb887bc33d962c3a3acc00df6",
+                "sha256:464e66a04e740d754170be5e740657a3b3b6d2bcc567f0c3437879a6e6087ff6",
+                "sha256:46d6d20815064e8bb023ea8628cfb7402c0f0e83de2c2227a88097e239a7dffd",
+                "sha256:4df5019e7783d14b79217ad9c56edf1ba7485d614ad5a385d1b3c768635c81c0",
+                "sha256:4e52c96ca66de04be42ea2278012a2342d89f5e82b4512fb6fb7134e377e2e62",
+                "sha256:5254af7d8bdf4d5484c089f929cb7f5bafa59b4f01d4f48adda4be41e6d29f99",
+                "sha256:52ae5739e4b5d6317b52f5b040b1b6639e8af68a5b8fd606a8b08658fbd0cab5",
+                "sha256:53b9dd1abd70e257a6e32f934ebc482dac5edb8c93e23deb663eac724c30b026",
+                "sha256:6c0a5dc52fc74eb87c67374a4e554d4761fd42a4d01390b7e868b30d21f4b8bb",
+                "sha256:73b3d43e04cc4b228fa6fa5d796409ece6fcb53a6c270eb2048109cbcbc3b9c2",
+                "sha256:74161d827407f4db9072011adcfb825b5258a5ccb3d2cd518dd6c9edea9e30f1",
+                "sha256:75f0ee6839532e52a3a53f80ce64925ed4aed697dd3fa890c4c918f3304bd4f4",
+                "sha256:839dd72545ef7ba78fd2aa1a5dd07b33696adf3e68fae7f31327161c1093001b",
+                "sha256:8be05be57dc5c7b4a0b24edcaa2f7275866d9c907725226cdde46da09367d923",
+                "sha256:8e8fd0a22c9d92af3a34f91e8a2594eeb35cba90ab643c5e0e643567dc8be43e",
+                "sha256:a873e4d4954f865dcb60bdc4914af7eaae48fb56b60ed6daa1d6251c72f5337c",
+                "sha256:ab845f1f51f7eb750a78937be9f79baea4a42c7960f5a94dde34e69f3cce1988",
+                "sha256:b1e981fe1aff1fd11627f531524826a4dcc1f26c726235a52fcb62ded27d150f",
+                "sha256:b4b0d31f2052b3f9f9b5327024dc629a253a83d8649d4734ca7f35b60ec3e9e5",
+                "sha256:c6ac7e45367b1317e56f1461719c853fd6825226f45b835df7436bb04031fd8a",
+                "sha256:daf21aa33ee9b351f66deed30a3d450ab55c14242cfdfcd377798e2c0d25c9f1",
+                "sha256:e9f7d1d8c26a6a12c23421061f9022bb62704e38211fe375c645485f38df34a2",
+                "sha256:f6061a31880c1ed6b6ce341215336e2f3d0c1deccd84957b6fa8ca474b41e89f"
+            ],
+            "markers": "python_version < '3.9' and platform_python_implementation == 'CPython'",
+            "version": "==0.2.2"
         },
         "six": {
             "hashes": [
@@ -71,6 +108,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==7.1.2"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:ace61d5fc652dc280e7b6b4ff732a9c2d40db2c0f92bc6cb74e07b73d53a1771",
+                "sha256:fa5daa4477a7414ae34e95942e4dd07f62adf589143c875c133c1e53c4eff38d"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==3.4.0"
         },
         "iniconfig": {
             "hashes": [
@@ -228,7 +273,16 @@
                 "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c",
                 "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"
             ],
+            "markers": "python_version < '3.8'",
             "version": "==3.7.4.3"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108",
+                "sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.4.0"
         }
     }
 }

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -2,7 +2,5 @@
 pip3 install --upgrade pip
 pip3 install --no-cache-dir pipenv
 
-pipenv --python 3.9
-
 pipenv lock --pre
 pipenv install --dev

--- a/test/test_recurr_txns.py
+++ b/test/test_recurr_txns.py
@@ -35,9 +35,8 @@ def test_it_gets_correct_rrule(start_date, txn_dict_base):
         "dtstart": start_date,
     }
 
-    txn_rrule = get_txn_rrule(
-        txn_dict_base | {"rrule": rrule_info}, default_until=datetime(2020, 12, 31)
-    )
+    txn_dict = {**{"rrule": rrule_info}, **txn_dict_base}
+    txn_rrule = get_txn_rrule(txn_dict, default_until=datetime(2020, 12, 31))
 
     # Check for correct count and details of the first transaction
     assert len(list(txn_rrule)) == 3
@@ -49,5 +48,6 @@ def test_it_gets_correct_rrule(start_date, txn_dict_base):
 
 
 def test_it_shows_correct_string(txn_dict_base, start_date, tab_map_dict):
-    txn_string = show_txn_str(txn_dict_base | {"dt": start_date}, tab_map_dict)
+    txn_dict = {**{"dt": start_date}, **txn_dict_base}
+    txn_string = show_txn_str(txn_dict, tab_map_dict)
     assert txn_string == ["12/12/2020", "Martha Terry; Dog walking", "", "$35.50"]


### PR DESCRIPTION
### What

* Downgrade python to a minimum of 3.6 by updating:

  - The two `Pipfile`s to include new dependencies
  - `Dockerfile` to use a different base image
  - `script/bootstrap` to use the new version
  - The test file that uses the new dictionary union operator brought in with Python 3.9

* Update the workflow to test three Python versions
* Remove `--pull` option from `make build`

### Why

* Using an older version of Python will make the project easier to install
* Images are not being pushed remotely for now, so `--pull` is not necessary

Closes #18